### PR TITLE
Fix import path for global CSS

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,4 @@
-import '@/styles/globals.css';
+import '../styles/globals.css';
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />;


### PR DESCRIPTION
## Summary
- fix wrong path to global CSS file in pages/_app.js

## Testing
- `npm run build` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*