### PR TITLE
Improve layout with sidebars, camera/mic controls and canvas

### DIFF
--- a/components/ChatSidebar.js
+++ b/components/ChatSidebar.js
@@ -1,0 +1,23 @@
+export default function ChatSidebar({ messages, input, setInput, onSend, onTalk, micEnabled }) {
+  return (
+    <aside className="w-80 bg-gray-900 text-cyan-300 p-4 flex flex-col">
+      <h2 className="text-xl font-bold mb-2">Chat</h2>
+      <div className="flex-1 overflow-y-auto space-y-1 mb-2">
+        {messages.map((m, i) => (
+          <div key={i} className={m.from === 'user' ? 'text-white' : 'text-green-400'}>{m.text}</div>
+        ))}
+      </div>
+      <input
+        className="w-full p-2 bg-gray-800 border border-cyan-400 mb-2"
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        onKeyDown={e => { if (e.key === 'Enter') onSend(input); }}
+        placeholder="Type your message"
+      />
+      <div className="flex gap-2">
+        <button className="flex-1 bg-cyan-400 text-black py-2" onClick={() => onSend(input)}>Send</button>
+        <button className="flex-1 bg-cyan-400 text-black py-2 disabled:opacity-50" onClick={onTalk} disabled={!micEnabled}>Talk</button>
+      </div>
+    </aside>
+  );
+}

--- a/components/ConversationsSidebar.js
+++ b/components/ConversationsSidebar.js
@@ -1,0 +1,15 @@
+export default function ConversationsSidebar({ conversations = [] }) {
+  return (
+    <aside className="w-56 bg-gray-900 text-cyan-300 p-4 space-y-2 overflow-y-auto">
+      <h2 className="text-xl font-bold mb-2">Conversations</h2>
+      {conversations.length === 0 && (
+        <div className="text-sm text-gray-400">No conversations</div>
+      )}
+      {conversations.map((c, i) => (
+        <div key={i} className="p-2 bg-gray-800 rounded cursor-pointer hover:bg-gray-700">
+          {c.title}
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/components/Settings.js
+++ b/components/Settings.js
@@ -1,20 +1,21 @@
-import { useState } from 'react';
-
-export default function Settings({ voice, setVoice }) {
+export default function Settings({ voice, setVoice, onClose }) {
   return (
-    <div className="bg-gray-900 p-3 rounded space-y-2 text-left">
-      <h2 className="font-bold text-cyan-300">Settings</h2>
-      <label className="block text-sm">
-        Voice language
-        <select
-          value={voice}
-          onChange={e => setVoice(e.target.value)}
-          className="ml-2 bg-black border border-cyan-300 text-cyan-300"
-        >
-          <option value="en-US">en-US</option>
-          <option value="en-GB">en-GB</option>
-        </select>
-      </label>
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center">
+      <div className="bg-gray-900 p-4 rounded space-y-4 w-80 text-left">
+        <h2 className="text-xl font-bold text-cyan-300">Settings</h2>
+        <label className="block text-sm">
+          Voice language
+          <select
+            value={voice}
+            onChange={e => setVoice(e.target.value)}
+            className="ml-2 bg-black border border-cyan-300 text-cyan-300"
+          >
+            <option value="en-US">en-US</option>
+            <option value="en-GB">en-GB</option>
+          </select>
+        </label>
+        <button onClick={onClose} className="w-full py-2 bg-cyan-400 text-black rounded">Close</button>
+      </div>
     </div>
   );
 }

--- a/components/ThreeCanvas.js
+++ b/components/ThreeCanvas.js
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+
+const THREE_SRC = 'https://unpkg.com/three@0.152.2/build/three.min.js';
+
+export default function ThreeCanvas({ level }) {
+  const mountRef = useRef(null);
+  const meshRef = useRef(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const script = document.createElement('script');
+    script.src = THREE_SRC;
+    script.onload = init;
+    document.head.appendChild(script);
+    let renderer, scene, camera, frameId;
+
+    function init() {
+      const THREE = window.THREE;
+      if (!THREE) return;
+      const width = mount.clientWidth;
+      const height = mount.clientHeight;
+      renderer = new THREE.WebGLRenderer({ alpha: true });
+      renderer.setSize(width, height);
+      mount.appendChild(renderer.domElement);
+      scene = new THREE.Scene();
+      camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+      camera.position.z = 4;
+      const geometry = new THREE.IcosahedronGeometry(1, 1);
+      const material = new THREE.MeshBasicMaterial({ color: 0x00ffff, wireframe: true });
+      const mesh = new THREE.Mesh(geometry, material);
+      meshRef.current = mesh;
+      scene.add(mesh);
+      animate();
+    }
+    function animate() {
+      frameId = requestAnimationFrame(animate);
+      if (meshRef.current) {
+        meshRef.current.rotation.x += 0.01;
+        meshRef.current.rotation.y += 0.01;
+      }
+      renderer && renderer.render(scene, camera);
+    }
+    return () => {
+      cancelAnimationFrame(frameId);
+      mount.innerHTML = '';
+      if (script.parentNode) script.parentNode.removeChild(script);
+    };
+  }, []);
+
+  useEffect(() => {
+    const mesh = meshRef.current;
+    if (mesh) {
+      const s = 1 + level * 2;
+      mesh.scale.set(s, s, s);
+    }
+  }, [level]);
+
+  return <div ref={mountRef} className="w-full h-full"></div>;
+}

--- a/components/Visualizer.js
+++ b/components/Visualizer.js
@@ -2,10 +2,11 @@ import { useEffect, useRef } from 'react';
 
 const THREE_SRC = 'https://unpkg.com/three@0.152.2/build/three.min.js';
 
-export default function Visualizer() {
+export default function Visualizer({ enabled, onLevel }) {
   const mountRef = useRef(null);
 
   useEffect(() => {
+    if (!enabled) return;
     let renderer, scene, camera, bars = [];
     let analyser, dataArray, audioCtx, source;
     let animationId;
@@ -54,9 +55,14 @@ export default function Visualizer() {
       animationId = requestAnimationFrame(animate);
       if (analyser) {
         analyser.getByteFrequencyData(dataArray);
+        let sum = 0;
         bars.forEach((bar, i) => {
-          bar.scale.y = Math.max(0.1, dataArray[i] / 50);
+          const val = dataArray[i];
+          sum += val;
+          bar.scale.y = Math.max(0.1, val / 50);
         });
+        const level = sum / dataArray.length / 255;
+        onLevel && onLevel(level);
       }
       renderer && renderer.render(scene, camera);
     }
@@ -70,7 +76,7 @@ export default function Visualizer() {
       mount.innerHTML = '';
       if (script.parentNode) script.parentNode.removeChild(script);
     };
-  }, []);
+  }, [enabled]);
 
-  return <div ref={mountRef} className="w-full h-64 bg-black"></div>;
+  return <div ref={mountRef} className="w-full h-24 bg-black rounded"></div>;
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,14 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
 import Visualizer from '../components/Visualizer';
+import ThreeCanvas from '../components/ThreeCanvas';
 import Settings from '../components/Settings';
+import ConversationsSidebar from '../components/ConversationsSidebar';
+import ChatSidebar from '../components/ChatSidebar';
 
 export default function Home() {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [voice, setVoice] = useState('en-US');
+  const [showSettings, setShowSettings] = useState(false);
+  const [micEnabled, setMicEnabled] = useState(false);
+  const [cameraEnabled, setCameraEnabled] = useState(false);
+  const [level, setLevel] = useState(0);
   const recognitionRef = useRef(null);
+  const streamRef = useRef(null);
 
+  // setup speech recognition when mic enabled or voice changes
   useEffect(() => {
+    if (!micEnabled) return;
     const SpeechRecognition = typeof window !== 'undefined' && (window.SpeechRecognition || window.webkitSpeechRecognition);
     if (SpeechRecognition) {
       const recog = new SpeechRecognition();
@@ -19,20 +29,31 @@ export default function Home() {
       };
       recognitionRef.current = recog;
     }
-    if (typeof navigator !== 'undefined') {
+  }, [voice, micEnabled]);
+
+  // handle camera enable/disable
+  useEffect(() => {
+    const video = document.getElementById('webcam');
+    if (!video) return;
+    if (cameraEnabled && typeof navigator !== 'undefined') {
       navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
-        const video = document.getElementById('webcam');
-        if (video) video.srcObject = stream;
+        streamRef.current = stream;
+        video.srcObject = stream;
       }).catch(() => {});
+    } else {
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach(t => t.stop());
+        streamRef.current = null;
+      }
+      video.srcObject = null;
     }
-    // cleanup
     return () => {
-      const video = document.getElementById('webcam');
-      if (video && video.srcObject) {
-        video.srcObject.getTracks().forEach(t => t.stop());
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach(t => t.stop());
+        streamRef.current = null;
       }
     };
-  }, [voice]);
+  }, [cameraEnabled]);
 
   const handleSend = async (text) => {
     if (!text) return;
@@ -59,35 +80,45 @@ export default function Home() {
   };
 
   const startVoice = () => {
-    recognitionRef.current && recognitionRef.current.start();
+    if (micEnabled && recognitionRef.current) recognitionRef.current.start();
   };
 
   return (
-    <div className="w-full max-w-xl mx-auto text-center space-y-4">
-      <h1 className="text-3xl font-bold">Dexter</h1>
-      <Visualizer />
-      <div className="flex gap-4 justify-center">
-        <video id="webcam" autoPlay muted width="320" height="240" className="rounded" />
-        <Settings voice={voice} setVoice={setVoice} />
-      </div>
-      <div className="bg-black/50 p-4 rounded space-y-2">
-        <div className="h-72 overflow-y-auto text-left space-y-1">
-          {messages.map((m, i) => (
-            <div key={i} className={m.from === 'user' ? 'text-white' : 'text-green-400'}>{m.text}</div>
-          ))}
+    <div className="h-screen flex text-cyan-300">
+      <ConversationsSidebar conversations={[]} />
+      <div className="flex-1 flex flex-col">
+        <div className="flex justify-end gap-2 p-2 bg-gray-800">
+          <button onClick={() => setCameraEnabled(v => !v)} className="px-3 py-1 bg-cyan-400 text-black rounded">
+            {cameraEnabled ? 'Disable' : 'Enable'} Camera
+          </button>
+          <button onClick={() => setMicEnabled(v => !v)} className="px-3 py-1 bg-cyan-400 text-black rounded">
+            {micEnabled ? 'Disable' : 'Enable'} Mic
+          </button>
+          <button onClick={() => setShowSettings(true)} className="px-3 py-1 bg-cyan-400 text-black rounded">
+            Settings
+          </button>
         </div>
-        <div className="flex gap-2">
-          <input
-            className="flex-1 p-2 bg-gray-900 border border-cyan-300 text-cyan-300"
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') handleSend(input); }}
-            placeholder="Type your message"
+        <div className="flex flex-1 overflow-hidden">
+          <div className="w-64 p-4 flex flex-col items-center bg-gray-900">
+            <video id="webcam" autoPlay muted className={`w-full h-48 bg-gray-700 rounded mb-2 ${cameraEnabled ? '' : 'hidden'}`} />
+            <Visualizer enabled={micEnabled} onLevel={setLevel} />
+          </div>
+          <div className="flex-1 flex items-center justify-center bg-black">
+            <ThreeCanvas level={level} />
+          </div>
+          <ChatSidebar
+            messages={messages}
+            input={input}
+            setInput={setInput}
+            onSend={handleSend}
+            onTalk={startVoice}
+            micEnabled={micEnabled}
           />
-          <button className="px-3 py-2 bg-cyan-400 text-black" onClick={() => handleSend(input)}>Send</button>
-          <button className="px-3 py-2 bg-cyan-400 text-black" onClick={startVoice}>Talk</button>
         </div>
       </div>
+      {showSettings && (
+        <Settings voice={voice} setVoice={setVoice} onClose={() => setShowSettings(false)} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor Visualizer to allow enabling/disabling mic and report volume
- add animated Three.js canvas that scales with voice level
- implement conversation and chat sidebars
- move Settings into a popup modal
- reorganize page layout with camera/mic toggles and new sidebars

## Testing
- `npm run build`